### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/access.js
+++ b/access.js
@@ -11,7 +11,7 @@ function field(root, name, value){
         if(!name.length){
             if(value) current[fieldName] = value;
             return current[fieldName];
-        }else if (!(isPrototypePolluted(fieldName))) current = current[fieldName];
+        }else if (!isPrototypePolluted(fieldName)) current = current[fieldName];
     }
     return undefined;
 }

--- a/access.js
+++ b/access.js
@@ -11,7 +11,7 @@ function field(root, name, value){
         if(!name.length){
             if(value) current[fieldName] = value;
             return current[fieldName];
-        }else current = current[fieldName];
+        }else if (!(isPrototypePolluted(fieldName))) current = current[fieldName];
     }
     return undefined;
 }
@@ -23,6 +23,10 @@ function objectField(obj, field, value){
         writable: false,
         value: value
     });
+}
+
+function isPrototypePolluted(key) {
+    return ['__proto__', 'constructor', 'prototype'].includes(key);
 }
 
 module.exports = {


### PR DESCRIPTION
### :bar_chart: Metadata *

`object-accessor` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-object-accessor

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var objectAccessor = require("object-accessor")
var obj = {}
console.log("Before : " + {}.polluted);
objectAccessor.set(obj,"__proto__.polluted","Yes! Its Polluted");
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i object-accessor # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: true
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/104122627-2529c580-536c-11eb-8515-4ad26950f242.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
